### PR TITLE
fix: Tallies total from cart items rather than Wix cart total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2020-08-05
+
+### Fixes
+- Issue with the Wix cart object sometimes ignoring discounts [@andiscrete](https://github.com/andiscrete).
+
 ## [0.5.4] - 2020-07-27
 
 ### Changes

--- a/payments.jsw
+++ b/payments.jsw
@@ -162,11 +162,14 @@ export async function generateCartPayload() {
         };
         const application = await createApplication(applicationObj);
         const items = getItemsFromCart(cart);
+        const itemsTotal = items.reduce((acc, item) => {
+            return acc + item.price;
+        }, 0);
         let returnObj = {
             apiKey: apiKey,
             items: items,
             currency: cart.currency.code,
-            total: (cart.totals.total) * 100,
+            total: (itemsTotal) * 100,
             paymentId: application._id,
             pluginVersion: pluginVersion,
             url: siteUrl


### PR DESCRIPTION
Apparently Wix plays fast and loose regarding when it adds discounts to it's internal cart object's total. This fix uses the items list that we eventually send to the merchant sdk to generate a more reliable cart total instead